### PR TITLE
feat: `requestPhoneAuth` 요청 시 site_name 설정 가능하게 함

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -74,6 +74,10 @@ interface IRequestPhoneAuth {
    * 앱해쉬 문자열 (Google SMS Retriever API 사용 시)
    */
   app_hash_str?: string;
+  /**
+   * 사이트명. 미입력시 인스턴스 생성시 입력한 사이트명이 사용됨.
+   */
+  site_name?: string;
 }
 
 export default class OKCert {
@@ -112,7 +116,7 @@ export default class OKCert {
       TEL_NO: body.tel_no,
       USER_IP: body.user_ip,
       SITE_URL: this.site_url,
-      SITE_NAME: this.site_name,
+      SITE_NAME: body.site_name || this.site_name,
       RQST_CAUS_CD: body.rqst_caus_cd,
       CHNL_CD: '0000', // 고정
       APP_HASH_STR: body.app_hash_str,


### PR DESCRIPTION
KCB 개발 문서 상으로는 본인확인 요청 시 request params에 `SITE_NAME`으로 요청 사이트명을 설정할 수 있습니다. 하지만 이 라이브러리에서는 `OKCertClass`의 인스턴스를 생성할 때 `site_name`을 주입하고 그것만을 사용해, 요청마다 다른 `site_name`값을 사용할 수 없습니다.

body에 `site_name`을 포함하면 그 값을 사용하고, 포함하지 않으면 인스턴스를 생성할 때 입력한 `site_name`값을 사용하도록 수정하였습니다.